### PR TITLE
fix: avoid devalidation of gtfs stage

### DIFF
--- a/matsim/scenario/supply/gtfs.py
+++ b/matsim/scenario/supply/gtfs.py
@@ -6,13 +6,13 @@ def configure(context):
     context.stage("matsim.runtime.java")
     context.stage("matsim.runtime.pt2matsim")
     context.stage("data.gtfs.cleaned")
-    context.stage("synthesis.population.spatial.home.locations")
+    context.stage("data.spatial.iris")
 
     context.config("gtfs_date", "dayWithMostServices")
 
 def execute(context):
     gtfs_path = "%s/output" % context.path("data.gtfs.cleaned")
-    crs = context.stage("synthesis.population.spatial.home.locations").crs
+    crs = context.stage("data.spatial.iris").crs
 
     pt2matsim.run(context, "org.matsim.pt2matsim.run.Gtfs2TransitSchedule", [
         gtfs_path,


### PR DESCRIPTION
Previously, the `gtfs` data stage depended on the home locations of the synthetic population to obtain the CRS that should be used. This led to rerunning the whole public transport network generation and matching when the sample size is changed. This PR now lets the stage obtain the CRS from the `iris` data stage, which is independent of sample size.