### PR TITLE
fix: handling of attribute collisions in gtfs

### DIFF
--- a/data/gtfs/utils.py
+++ b/data/gtfs/utils.py
@@ -296,31 +296,32 @@ def merge_two_feeds(first, second, suffix = "_merged"):
             df_first = first[collision["slot"]]
             df_second = second[collision["slot"]]
 
-            df_first[collision["identifier"]] = df_first[collision["identifier"]].astype(str)
-            df_second[collision["identifier"]] = df_second[collision["identifier"]].astype(str)
+            if collision["identifier"] in df_first and collision["identifier"] in df_second:
+                df_first[collision["identifier"]] = df_first[collision["identifier"]].astype(str)
+                df_second[collision["identifier"]] = df_second[collision["identifier"]].astype(str)
 
-            df_concat = pd.concat([df_first, df_second], sort = True).drop_duplicates()
-            duplicate_ids = list(df_concat[df_concat[collision["identifier"]].duplicated()][
-                collision["identifier"]].astype(str).unique())
+                df_concat = pd.concat([df_first, df_second], sort = True).drop_duplicates()
+                duplicate_ids = list(df_concat[df_concat[collision["identifier"]].duplicated()][
+                    collision["identifier"]].astype(str).unique())
 
-            if len(duplicate_ids) > 0:
-                print("   Found %d duplicate identifiers in %s" % (
-                    len(duplicate_ids), collision["slot"]))
+                if len(duplicate_ids) > 0:
+                    print("   Found %d duplicate identifiers in %s" % (
+                        len(duplicate_ids), collision["slot"]))
 
-                replacement_ids = [str(id) + suffix for id in duplicate_ids]
+                    replacement_ids = [str(id) + suffix for id in duplicate_ids]
 
-                df_second[collision["identifier"]] = df_second[collision["identifier"]].replace(
-                    duplicate_ids, replacement_ids
-                )
+                    df_second[collision["identifier"]] = df_second[collision["identifier"]].replace(
+                        duplicate_ids, replacement_ids
+                    )
 
-                for ref_slot, ref_identifier in collision["references"]:
-                    if ref_slot in first and ref_slot in second:
-                        first[ref_slot][ref_identifier] = first[ref_slot][ref_identifier].astype(str)
-                        second[ref_slot][ref_identifier] = second[ref_slot][ref_identifier].astype(str)
+                    for ref_slot, ref_identifier in collision["references"]:
+                        if ref_slot in first and ref_slot in second:
+                            first[ref_slot][ref_identifier] = first[ref_slot][ref_identifier].astype(str)
+                            second[ref_slot][ref_identifier] = second[ref_slot][ref_identifier].astype(str)
 
-                        second[ref_slot][ref_identifier] = second[ref_slot][ref_identifier].replace(
-                            duplicate_ids, replacement_ids
-                        )
+                            second[ref_slot][ref_identifier] = second[ref_slot][ref_identifier].replace(
+                                duplicate_ids, replacement_ids
+                            )
 
     for slot in REQUIRED_SLOTS + OPTIONAL_SLOTS:
         if slot in first and slot in second:


### PR DESCRIPTION
Only handle collisions of identifiers in GTFS files if the respective columns really exist in both files. We just had a case where the attribute was missing in one, which caused an error.