### PR TITLE
feat: ignore change of number of threads

### DIFF
--- a/matsim/scenario/supply/processed.py
+++ b/matsim/scenario/supply/processed.py
@@ -10,7 +10,7 @@ def configure(context):
     context.stage("matsim.scenario.supply.gtfs")
 
     context.config("data_path")
-    context.config("processes")
+    context.config("processes", volatile = True)
 
 def execute(context):
     # Prepare input paths

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -21,7 +21,7 @@ def configure(context):
     context.stage("data.spatial.codes")
 
     context.config("sampling_rate")
-    context.config("processes")
+    context.config("processes", volatile = True)
     context.config("random_seed")
 
     context.config("output_prefix", "ile_de_france_")

--- a/synthesis/population/matched.py
+++ b/synthesis/population/matched.py
@@ -25,7 +25,7 @@ DEFAULT_MATCHING_ATTRIBUTES = [
 ]
 
 def configure(context):
-    context.config("processes")
+    context.config("processes", volatile = True)
     context.config("random_seed")
     context.config("matching_minimum_observations", 20)
     context.config("matching_attributes", DEFAULT_MATCHING_ATTRIBUTES)

--- a/synthesis/population/spatial/secondary/locations.py
+++ b/synthesis/population/spatial/secondary/locations.py
@@ -17,7 +17,7 @@ def configure(context):
     context.stage("synthesis.locations.secondary")
 
     context.config("random_seed")
-    context.config("processes")
+    context.config("processes", volatile = True)
 
     context.config("secloc_maximum_iterations", np.inf)
 


### PR DESCRIPTION
Increasing the number of threads (option `processes`) should only have an impact on performance and use of resources, not on the results. Therefore, this PR makes `processes` volatile such that stages are not re-executed when this option changes.