### PR TITLE
chore: update urban type data to 2024

### DIFF
--- a/data/spatial/urban_type.py
+++ b/data/spatial/urban_type.py
@@ -23,7 +23,7 @@ def configure(context):
     context.stage("data.spatial.municipalities")
 
     context.config("data_path")
-    context.config("urban_type_path", "urban_type/UU2020_au_01-01-2023.zip")
+    context.config("urban_type_path", "urban_type/UU2020_au_01-01-2024.zip")
 
 def execute(context):
     with zipfile.ZipFile("{}/{}".format(
@@ -31,8 +31,8 @@ def execute(context):
         assert len(archive.filelist) == 1
         with archive.open(archive.filelist[0]) as f:
             df = pd.read_excel(f, sheet_name = "Composition_communale", skiprows = 5)
-            
-    df = df[["CODGEO", "STATUT_2017"]].copy()
+
+    df = df[["CODGEO", "STATUT_COM_UU"]].copy()
     df = df.set_axis(["commune_id", "urban_type"], axis = "columns")
 
     # Cities that have districts are not detailed in the UU file, only the whole city is mentioned
@@ -50,7 +50,7 @@ def execute(context):
             "commune_id": replacement_codes,
             "urban_type": [base_type] * len(replacement_codes)
         })])
-    
+
     df = df[~df["commune_id"].isin(cities_with_districts.keys())]
 
     # Clean unités urbaines

--- a/docs/population/population_execution.md
+++ b/docs/population/population_execution.md
@@ -172,8 +172,8 @@ The `*default*` trigger will be replaced by the default list of matching attribu
 Note that not all HTS implement the urban type, so matching may not work with some implementations. Most of them, however, contain the data, we just need to update the code to read them in.
 
 To make use of the urban type, the following data is needed:
-- [Download the urban type data from INSEE](https://www.insee.fr/fr/information/4802589). The pipeline is currently compatible with the 2023 data set (referencing 2020 boundaries). 
-- Put the downloaded *zip* file into `data/urban_type`, so you will have the file `data/urban_type/UU2020_au_01-01-2023.zip`
+- [Download the urban type data from INSEE](https://www.insee.fr/fr/information/4802589). The pipeline is currently compatible with the 2024 data set (referencing 2020 boundaries). 
+- Put the downloaded *zip* file into `data/urban_type`, so you will have the file `data/urban_type/UU2020_au_01-01-2024.zip`
 
 Then, you should be able to run the pipeline with the configuration explained above.
 

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -791,19 +791,19 @@ def create(output_path):
     print("Creating urban type ...")
     df_urban_type = df_codes[["DEPCOM"]].copy().rename(columns = { "DEPCOM": "CODGEO" })
     df_urban_type = df_urban_type.drop_duplicates()
-    df_urban_type["STATUT_2017"] = [["B", "C", "I", "H"][k % 4] for k in range(len(df_urban_type))]
+    df_urban_type["STATUT_COM_UU"] = [["B", "C", "I", "H"][k % 4] for k in range(len(df_urban_type))]
 
     df_urban_type = pd.concat([df_urban_type, pd.DataFrame({
         "CODGEO": ["75056", "69123", "13055"],
-        "STATUT_2017": ["C", "C", "C"]
+        "STATUT_COM_UU": ["C", "C", "C"]
     })])
 
     print("Hash", "df_urban_type", pd.util.hash_pandas_object(df_urban_type, index = True).sum())
     assert pd.util.hash_pandas_object(df_urban_type, index = True).sum() == 15662019550405027472
 
     os.mkdir("%s/urban_type" % output_path)
-    with zipfile.ZipFile("%s/urban_type/UU2020_au_01-01-2023.zip" % output_path, "w") as archive:
-        with archive.open("UU2020_au_01-01-2023.xlsx", "w") as f:
+    with zipfile.ZipFile("%s/urban_type/UU2020_au_01-01-2024.zip" % output_path, "w") as archive:
+        with archive.open("UU2020_au_01-01-2024.xlsx", "w") as f:
             df_urban_type.to_excel(f, startrow = 5, sheet_name = "Composition_communale", index = False)
 
     # set scenario cutter shape


### PR DESCRIPTION
In a new version of the urban type data from INSEE, the urban type column was renamed from `STATUT_2017` to `STATUT_COM_UU`. This PR fixes this and update the data to 2024 at the same time.

Note that 2026 data is available, but it's best to keep in sync with census data to have no mismatch INSEE ids when merging the data, although I'm not actually sure which year is used by the census data.