### PR TITLE
fix: optional agency id in GTFS

### DIFF
--- a/data/gtfs/utils.py
+++ b/data/gtfs/utils.py
@@ -100,6 +100,8 @@ def read_feed(path):
 
     if "agency" in feed:
         df_agency = feed["agency"]
+        if "agency_id" not in df_agency.columns:
+            df_agency["agency_id"] = "generic"
         df_agency.loc[df_agency["agency_id"].isna(), "agency_id"] = "generic"
 
     if "routes" in feed:


### PR DESCRIPTION
According to the [GTFS specification](https://gtfs.org/documentation/schedule/reference/#agencytxt). The agency_id column is optional in the agency.txt file. This wasn't the case in the code which handled NAN values in that column but not its absence. 