### PR TITLE
fix: population sampling and validation

### DIFF
--- a/data/census/cleaned.py
+++ b/data/census/cleaned.py
@@ -54,7 +54,7 @@ def execute(context):
     df["iris_id"] = df["iris_id"].astype("category")
 
     # Age
-    df["age"] = df["AGED"].apply(lambda x: "0" if x == "000" else x.lstrip("0")).astype(int)
+    df["age"] = df["AGEREV"].apply(lambda x: "0" if x == "000" else x.lstrip("0")).astype(int)
 
     # Clean COUPLE
     df["couple"] = df["COUPLE"] == "1"

--- a/data/census/raw.py
+++ b/data/census/raw.py
@@ -16,7 +16,7 @@ def configure(context):
 COLUMNS_DTYPES = {
     "CANTVILLE":"str",
     "NUMMI":"str",
-    "AGED":"str",
+    "AGEREV":"str",
     "COUPLE":"str",
     "GS":"str",
     "STAT_GSEC":"str",

--- a/synthesis/population/output.py
+++ b/synthesis/population/output.py
@@ -1,0 +1,16 @@
+"""
+This stage outputs the census-based generated population (before enrichment).
+"""
+
+def configure(context):
+    context.stage("synthesis.population.sampled")
+
+    context.config("output_path")
+    context.config("output_prefix", "ile_de_france_")
+
+def execute(context):
+    output_path = context.config("output_path")
+    output_prefix = context.config("output_prefix")
+    
+    df_census = context.stage("synthesis.population.sampled")
+    df_census.to_parquet("%s/%spopulation.parquet" % (output_path, output_prefix))

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -593,7 +593,7 @@ def create(output_path):
         for person_index in range(CENSUS_HOUSEHOLD_MEMBERS):
             persons.append(dict(
                 CANTVILLE = "ABCE", NUMMI = household_id,
-                AGED = "%03d" % random.integers(5, 90), COUPLE = random.choice([1, 2]),
+                AGEREV = "%03d" % random.integers(5, 90), COUPLE = random.choice([1, 2]),
                 GS = random.choice(["1", "2", "3", "4", "5", "6", "Z"]),
                 STAT_GSEC = random.choice(["", "32"], p = [0.85, 0.15]),
                 DEPT = department, IRIS = iris, REGION = region, ETUD = random.choice([1, 2]),
@@ -607,7 +607,7 @@ def create(output_path):
             ))
 
     columns = [
-        "CANTVILLE", "NUMMI", "AGED", "COUPLE", "GS", "DEPT", "IRIS", "REGION",
+        "CANTVILLE", "NUMMI", "AGEREV", "COUPLE", "GS", "DEPT", "IRIS", "REGION",
         "ETUD", "ILETUD", "ILT", "IPONDI", "STAT_GSEC",
         "SEXE", "TACT", "TP", "TRANS", "VOIT", "DEROU"
     ]


### PR DESCRIPTION
- Tracks the fixes for #514.
- Makes it easy to extract a synthetic population early in the pipeline
- Uses now `AGEREV` instead of `AGED` for the person age as this makes the synthetic population comparable not only with the individualized census data, but also with INSEE's aggregated census data