### PR TITLE
chore: improve test data hashing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from . import testdata
+
+import pytest
+import tempfile
+import shutil
+import os
+
+@pytest.fixture(scope = "session")
+def data_path():
+    directory = "{}/.pytest-eqasim-france-fixtures".format(tempfile.gettempdir())
+
+    if os.path.exists(directory):
+        print("Cleaning up existing fixture data...")
+        shutil.rmtree(directory)
+
+    os.makedirs(directory)
+
+    print("Creating fixture data...")
+    testdata.create(directory)
+
+    print("Fixture data is ready!")
+    yield directory

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,9 +1,7 @@
 import synpp
 import os
 import hashlib, gzip
-from . import testdata
 import sqlite3
-import shutil, json
 
 class HashManager:
     def __init__(self):
@@ -80,10 +78,7 @@ class HashManager:
 
         return hash.hexdigest()
 
-def test_determinism(tmpdir):
-    data_path = str(tmpdir.mkdir("data"))
-    testdata.create(data_path)
-
+def test_determinism(data_path, tmpdir):
     for index in range(2):
         _test_determinism(index, data_path, tmpdir)
 
@@ -164,10 +159,7 @@ def _test_determinism(index, data_path, tmpdir):
 
     manager.finish()
 
-def test_determinism_matsim(tmpdir):
-    data_path = str(tmpdir.mkdir("data"))
-    testdata.create(data_path)
-
+def test_determinism_matsim(data_path, tmpdir):
     for index in range(2):
         _test_determinism_matsim(index, data_path, tmpdir)
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -115,22 +115,22 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_households.csv",
         "{}/ile_de_france_households.csv".format(output_path),
-        "c530f2c5448de05951badbb350596da1")
+        "9728bda2edb7c15ced3898eccb2ce118")
 
     manager.check(
         "ile_de_france_persons.csv",
         "{}/ile_de_france_persons.csv".format(output_path),
-        "534b4d6f9a4b3f4c2b2b0bc2e35c4587")
+        "c5ca0c82cf646c048e05fbb1c09a3a1a")
 
     manager.check(
         "ile_de_france_activities.csv",
         "{}/ile_de_france_activities.csv".format(output_path),
-        "89b38b842359c77e1f5a51692d0cd8e3")
+        "bbb81bd4033d9ff7abff86a814c381b0")
 
     manager.check(
         "ile_de_france_trips.csv",
         "{}/ile_de_france_trips.csv".format(output_path),
-        "766145c0025d1cebb99dda70b535f4a6")
+        "a0b0b4e69e9a1fbc7790670b95330b9a")
 
     manager.check(
         "ile_de_france_vehicle_types.csv",
@@ -140,27 +140,27 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_vehicles.csv",
         "{}/ile_de_france_vehicles.csv".format(output_path),
-        "4ceb5f779a32236859735219eebc45ad")
+        "4da2a3031482cfd730c9a87cbf173187")
 
     manager.check(
         "ile_de_france_activities.gpkg",
         "{}/ile_de_france_activities.gpkg".format(output_path),
-        "a3caa84f909456ef8c0e57243a343c27")
+        "31bd78190721a09f11822ee0010fcd89")
 
     manager.check(
         "ile_de_france_commutes.gpkg",
         "{}/ile_de_france_commutes.gpkg".format(output_path),
-        "1a5e7bfbb114ede94f520f0416c715b9")
+        "d58ad2123de0fdff85b5a27761342618")
 
     manager.check(
         "ile_de_france_homes.gpkg",
         "{}/ile_de_france_homes.gpkg".format(output_path),
-        "bb3b0ecc0796425b6c9f1d02833e146d")
+        "22b355038df4fc7da5cc21306e9a20f0")
 
     manager.check(
         "ile_de_france_trips.gpkg",
         "{}/ile_de_france_trips.gpkg".format(output_path),
-        "0d9c1bf9816273c8755d9390a04792d2")
+        "8503472b20aae5caa0cec6d2c8565553")
 
     manager.finish()
 
@@ -204,11 +204,11 @@ def _test_determinism_matsim(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_households.xml.gz",
         "{}/ile_de_france_households.xml.gz".format(output_path),
-        "4f3d950cedbe0a96971df577947a87dd")
+        "13ae95055e5d8987a109bf2431486a2e")
 
     manager.check(
         "ile_de_france_vehicles.xml.gz",
         "{}/ile_de_france_vehicles.xml.gz".format(output_path),
-        "63d2f2c7c8096d4f881a9a16c4e406e7")
+        "40db0b3031349b97028ff62832bd96f9")
 
     manager.finish()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,46 +1,11 @@
 import synpp
 import os
-import hashlib
-from . import testdata
 import pandas as pd
 
-def test_data(tmpdir):
-    data_path = str(tmpdir.mkdir("data"))
-    testdata.create(data_path)
-
+def run_population(data_path, tmpdir, hts, update = {}):
     cache_path = str(tmpdir.mkdir("cache"))
     output_path = str(tmpdir.mkdir("output"))
-    config = dict(
-        data_path = data_path, output_path = output_path,
-        regions = [10, 11], hts = "entd")
 
-    stages = [
-        dict(descriptor = "data.spatial.iris"),
-        dict(descriptor = "data.spatial.codes"),
-        dict(descriptor = "data.spatial.population"),
-        dict(descriptor = "data.bpe.cleaned"),
-        dict(descriptor = "data.income.municipality"),
-        dict(descriptor = "data.hts.entd.cleaned"),
-        dict(descriptor = "data.hts.egt.cleaned"),
-        dict(descriptor = "data.census.cleaned"),
-        dict(descriptor = "data.od.cleaned"),
-        dict(descriptor = "data.hts.output"),
-        dict(descriptor = "data.sirene.output"),
-    ]
-
-    synpp.run(stages, config, working_directory = cache_path)
-
-    assert os.path.isfile("%s/ile_de_france_hts_households.csv" % output_path)
-    assert os.path.isfile("%s/ile_de_france_hts_persons.csv" % output_path)
-    assert os.path.isfile("%s/ile_de_france_hts_trips.csv" % output_path)
-    assert os.path.isfile("%s/ile_de_france_sirene.gpkg" % output_path)
-
-def run_population(tmpdir, hts, update = {}):
-    data_path = str(tmpdir.mkdir("data"))
-    testdata.create(data_path)
-
-    cache_path = str(tmpdir.mkdir("cache"))
-    output_path = str(tmpdir.mkdir("output"))
     config = dict(
         data_path = data_path, output_path = output_path,
         regions = [10, 11], sampling_rate = 1.0, hts = hts,
@@ -63,9 +28,9 @@ def run_population(tmpdir, hts, update = {}):
     assert os.path.isfile("%s/ile_de_france_trips.gpkg" % output_path)
     assert os.path.isfile("%s/ile_de_france_meta.json" % output_path)
 
-    expected_activities = 2400
-    expected_persons = 480
-    expected_households = 160
+    expected_activities = 2205
+    expected_persons = 441
+    expected_households = 147
     expected_vehicles = expected_persons * 2
     expected_vehicle_types = 2
 
@@ -84,28 +49,28 @@ def run_population(tmpdir, hts, update = {}):
     assert expected_vehicles == len(pd.read_csv("%s/ile_de_france_vehicles.csv" % output_path, usecols = ["vehicle_id"], sep = ";"))
     assert expected_vehicle_types == len(pd.read_csv("%s/ile_de_france_vehicle_types.csv" % output_path, usecols = ["type_id"], sep = ";"))
 
-def test_population_with_entd(tmpdir):
-    run_population(tmpdir, "entd")
+def test_population_with_entd(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd")
 
-def test_population_with_egt(tmpdir):
-    run_population(tmpdir, "egt")
+def test_population_with_egt(data_path, tmpdir):
+    run_population(data_path, tmpdir, "egt")
 
-def test_population_with_mode_choice(tmpdir):
-    run_population(tmpdir, "entd", { "mode_choice": True })
+def test_population_with_mode_choice(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd", { "mode_choice": True })
 
-def test_population_with_fleet_sample(tmpdir):
-    run_population(tmpdir, "entd", { 
+def test_population_with_fleet_sample(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd", { 
         "vehicles_method": "fleet_sample",
         "vehicles_year": 2021
     })
 
-def test_population_with_bhepop2_income(tmpdir):
-    run_population(tmpdir, "egt", { 
+def test_population_with_bhepop2_income(data_path, tmpdir):
+    run_population(data_path, tmpdir, "egt", { 
         "income_assignation_method": "bhepop2"
     })
 
-def test_population_with_urban_type(tmpdir):
-    run_population(tmpdir, "entd", { 
+def test_population_with_urban_type(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd", { 
         "use_urban_type": True, 
         "matching_attributes": [
             "urban_type", "*default*"
@@ -113,8 +78,8 @@ def test_population_with_urban_type(tmpdir):
         "matching_minimum_observations": 5
     })
 
-def test_population_with_urban_type_and_egt(tmpdir):
-    run_population(tmpdir, "egt", { 
+def test_population_with_urban_type_and_egt(data_path, tmpdir):
+    run_population(data_path, tmpdir, "egt", { 
         "use_urban_type": True, 
         "matching_attributes": [
             "urban_type", "*default*"
@@ -122,14 +87,14 @@ def test_population_with_urban_type_and_egt(tmpdir):
         "matching_minimum_observations": 5
     })
 
-def test_population_with_motorcycles(tmpdir):
-    run_population(tmpdir, "entd", {
+def test_population_with_motorcycles(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd", {
         "with_motorcycles": True,
         "vehicles_method": "fleet_sample",
         "vehicles_year": 2021
     })
 
-def test_population_with_secondary_activity_force_model(tmpdir):
-    run_population(tmpdir, "entd", { 
+def test_population_with_secondary_activity_force_model(data_path, tmpdir):
+    run_population(data_path, tmpdir, "entd", { 
         "secondary_activities": dict(chain_solver = "force_model", maximum_iterations = 10)
     })

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,17 +1,13 @@
 import synpp
 import os
-from . import testdata
 
 TEST_NOISE = False
 
-def test_simulation(tmpdir):
+def test_simulation(data_path, tmpdir):
 
     test_noise = TEST_NOISE
     if os.environ.get("TEST_NOISE") is not None:
         test_noise = os.environ.get("TEST_NOISE").lower() == "true"
-
-    data_path = str(tmpdir.mkdir("data"))
-    testdata.create(data_path)
 
     cache_path = str(tmpdir.mkdir("cache"))
     output_path = str(tmpdir.mkdir("output"))

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -71,8 +71,6 @@ def create(output_path):
     ADDRESS_OBSERVATIONS = 2000
     SIRENE_OBSERVATIONS = 2000
 
-    random = np.random.default_rng(1000)
-
     REGION_LENGTH = 50 * 1e3
     DEPARTMENT_LENGTH = 25 * 1e3
     MUNICIPALITY_LENGTH = 5 * 1e3
@@ -230,6 +228,7 @@ def create(output_path):
     # Dataset: BPE
     # Required attributes: DCIRIS, LAMBERT_X, LAMBERT_Y, TYPEQU, DEPCOM, DEP
     print("Creating BPE ...")
+    random = np.random.default_rng(1000)
 
     # We put enterprises at the centroid of the shapes
     observations = BPE_OBSERVATIONS
@@ -348,6 +347,7 @@ def create(output_path):
 
     # Data set: ENTD
     print("Creating ENTD ...")
+    random = np.random.default_rng(2533)
 
     data = dict(
         Q_MENAGE = [],
@@ -456,11 +456,11 @@ def create(output_path):
     pd.DataFrame.from_records(data["K_DEPLOC"]).to_csv("%s/entd_2008/K_deploc.csv" % output_path, index = False, sep = ";")
 
     hashes = {
-        "Q_MENAGE": 13747765506488913060,
-        "Q_TCM_MENAGE": 11743608538769824299,
-        "Q_INDIVIDU": 10605303610959774056,
-        "Q_TCM_INDIVIDU": 14111705055958460361,
-        "K_DEPLOC": 8223897019656200695
+        "Q_MENAGE": 6916190433170563173,
+        "Q_TCM_MENAGE": 6980538473335852422,
+        "Q_INDIVIDU": 15145767072075638494,
+        "Q_TCM_INDIVIDU": 13969435991955395586,
+        "K_DEPLOC": 7631538890399794851
     }
 
     for slot in ["Q_MENAGE", "Q_TCM_MENAGE", "Q_INDIVIDU", "Q_TCM_INDIVIDU", "K_DEPLOC"]:
@@ -470,6 +470,7 @@ def create(output_path):
 
     # Data set: EGT
     print("Creating EGT ...")
+    random = np.random.default_rng(5632)
 
     data = dict(
         households = [],
@@ -561,9 +562,9 @@ def create(output_path):
     pd.DataFrame.from_records(data["trips"]).to_csv("%s/egt_2010/Deplacements_semaine.csv" % output_path, index = False, sep = ",")
 
     hashes = {
-        "households": 9610947733268415162,
-        "persons": 4225414291640515394,
-        "trips": 3642532006631400738,
+        "households": 11444390802329132734,
+        "persons": 7614014922097515207,
+        "trips": 14635367621539133620,
     }
 
     for slot in ["households", "persons", "trips"]:
@@ -573,6 +574,7 @@ def create(output_path):
 
     # Data set: Census
     print("Creating census ...")
+    random = np.random.default_rng(73523)
 
     persons = []
 
@@ -616,12 +618,13 @@ def create(output_path):
     df_persons.columns = columns
 
     print("Hash", "df_persons", pd.util.hash_pandas_object(df_persons, index = True).sum())
-    assert pd.util.hash_pandas_object(df_persons, index = True).sum() == 9906836554399977863
+    assert pd.util.hash_pandas_object(df_persons, index = True).sum() == 5371293800328552247
 
     df_persons.to_parquet("%s/rp_2022/RP2022_indcvi.parquet" % output_path)
 
     # Data set: commute flows
     print("Creating commute flows ...")
+    random = np.random.default_rng(82625)
 
     municipalities = df["municipality"].unique()
     observations = COMMUTE_FLOW_OBSERVATIONS
@@ -640,7 +643,7 @@ def create(output_path):
     df_work.columns = columns
 
     print("Hash", "df_work", pd.util.hash_pandas_object(df_work, index = True).sum())
-    assert pd.util.hash_pandas_object(df_work, index = True).sum() == 4226572591318659871
+    assert pd.util.hash_pandas_object(df_work, index = True).sum() == 6975741772103988418
 
     df_work.to_parquet("%s/rp_2022/RP2022_mobpro.parquet" % output_path)
 
@@ -657,12 +660,13 @@ def create(output_path):
     df_education.columns = columns
 
     print("Hash", "df_education", pd.util.hash_pandas_object(df_education, index = True).sum())
-    assert pd.util.hash_pandas_object(df_education, index = True).sum() == 4552268535654263404
+    assert pd.util.hash_pandas_object(df_education, index = True).sum() == 3071821450482011272
 
     df_education.to_parquet("%s/rp_2022/RP2022_mobsco.parquet" % output_path)
 
     # Data set: BD-TOPO
     print("Creating BD-TOPO ...")
+    random = np.random.default_rng(54582)
 
     observations = ADDRESS_OBSERVATIONS
 
@@ -690,7 +694,7 @@ def create(output_path):
     df_bdtopo.set_geometry(df_bdtopo.buffer(40),inplace=True,crs="EPSG:2154")
 
     print("Hash", "df_bdtopo", pd.util.hash_pandas_object(df_bdtopo, index = True).sum())
-    assert pd.util.hash_pandas_object(df_bdtopo, index = True).sum() == 15052525390832911939
+    assert pd.util.hash_pandas_object(df_bdtopo, index = True).sum() == 11745417358469153345
 
     os.mkdir("{}/bdtopo_idf".format(output_path))
     df_bdtopo.to_file("{}/bdtopo_idf/content.gpkg".format(output_path), layer = "batiment")
@@ -729,7 +733,7 @@ def create(output_path):
     df_ban = df_ban[:round(len(x)*.8)]
 
     print("Hash", "df_ban", pd.util.hash_pandas_object(df_ban, index = True).sum())
-    assert pd.util.hash_pandas_object(df_ban, index = True).sum() == 2128043709322238162
+    assert pd.util.hash_pandas_object(df_ban, index = True).sum() == 3264831854545569377
 
     os.mkdir("%s/ban_idf" % output_path)
 
@@ -738,6 +742,7 @@ def create(output_path):
 
     # Data set: SIRENE
     print("Creating SIRENE ...")
+    random = np.random.default_rng(8864)
 
     observations = SIRENE_OBSERVATIONS
 
@@ -754,7 +759,7 @@ def create(output_path):
     df_sirene["trancheEffectifsEtablissement"] = "03"
 
     print("Hash", "SIRENE ET", pd.util.hash_pandas_object(df_sirene, index = True).sum())
-    assert pd.util.hash_pandas_object(df_sirene, index = True).sum() == 11823850498057821917
+    assert pd.util.hash_pandas_object(df_sirene, index = True).sum() == 17429090226711180196
 
     os.mkdir("%s/sirene" % output_path)
     df_sirene.to_parquet(output_path + "/sirene/StockEtablissement_utf8.parquet", index = False)
@@ -765,7 +770,7 @@ def create(output_path):
     df_sirene.to_parquet(output_path + "/sirene/StockUniteLegale_utf8.parquet", index = False)
 
     print("Hash", "SIRENE UL", pd.util.hash_pandas_object(df_sirene, index = True).sum())
-    assert pd.util.hash_pandas_object(df_sirene, index = True).sum() == 3081936000399868577
+    assert pd.util.hash_pandas_object(df_sirene, index = True).sum() == 8449205416520787779
 
     # Data set: SIRENE GEOLOCATION
     print("Creating SIRENE GEOLOCATION...")
@@ -784,7 +789,7 @@ def create(output_path):
     })
 
     print("Hash", "SIRENE GEO", pd.util.hash_pandas_object(df_sirene_geoloc, index = True).sum())
-    assert pd.util.hash_pandas_object(df_sirene_geoloc, index = True).sum() == 11781731939284746012
+    assert pd.util.hash_pandas_object(df_sirene_geoloc, index = True).sum() == 12038323953301123794
 
     df_sirene_geoloc.to_parquet("%s/sirene/GeolocalisationEtablissement_Sirene_pour_etudes_statistiques_utf8.parquet" % output_path, index = False)
 
@@ -1082,6 +1087,7 @@ def create(output_path):
 
     # add 2rm dataset
     print("Creating 2RM dataset ...")
+    random = np.random.default_rng(12512)
 
     os.mkdir("%s/2rm" % output_path)
 


### PR DESCRIPTION
This PR updates the test data generation process. Instead of acting on one RNG that is initialized in the beginning, we create a new RNG for each data set. This way, updates to early data sets in the script will not affect otherwise untouched datasets that are generated later.

Furthermore, we now set up test data generation as a `session` fixture, which means that the data will be generated only once per test session!