### PR TITLE
chore: avoid testing pt2matsim

### DIFF
--- a/matsim/runtime/pt2matsim.py
+++ b/matsim/runtime/pt2matsim.py
@@ -31,7 +31,7 @@ def execute(context):
     ])
 
     # Build pt2matsim
-    maven.run(context, ["package", "-Dskip.surefire.tests"], cwd = "%s/pt2matsim" % context.path())
+    maven.run(context, ["package", "-Dskip.surefire.tests=True"], cwd = "%s/pt2matsim" % context.path())
     jar_path = "pt2matsim/target/pt2matsim-{}-shaded.jar".format(version)
 
     # Test pt2matsim


### PR DESCRIPTION
The tests for `pt2matsim` actually ran with every clone. Now we suppress testing correctly.