### PR TITLE
fix: GTFS-related problems

### DIFF
--- a/data/gtfs/utils.py
+++ b/data/gtfs/utils.py
@@ -83,6 +83,7 @@ def read_feed(path):
         if not "parent_station" in df_stops:
             print("WARNING Missing parent_station in stops, setting to empty string")
             df_stops["parent_station"] = ""
+        df_stops.loc[df_stops["parent_station"].isna() & (df_stops["location_type"] == 0), "location_type"] = 1
 
     if "transfers" in feed:
         df_transfers = feed["transfers"]

--- a/data/gtfs/utils.py
+++ b/data/gtfs/utils.py
@@ -312,7 +312,7 @@ def merge_two_feeds(first, second, suffix = "_merged"):
                     )
 
                     for ref_slot, ref_identifier in collision["references"]:
-                        if ref_slot in first and ref_slot in second:
+                        if ref_slot in second:
                             second[ref_slot][ref_identifier] = second[ref_slot][ref_identifier].replace(
                                 duplicate_ids, replacement_ids
                             )


### PR DESCRIPTION
This PR fixes two issues: 
- When merging a feed using both `calendar.txt` and `calendar_dates.txt` with another using just `calendar_dates.txt` and when IDs collide between `calendar_dates.txt`, the renaming of the ids in the first feed is not propagated into `calendar.txt`
-  Some GTFS feeds contain bad stops.txt where some stops have no parent station but have a type where a parent station is expected. This causes the pipeline to remove the stops. 