### PR TITLE
feat: generate primary locations for all employed persons

### DIFF
--- a/synthesis/population/spatial/primary/candidates.py
+++ b/synthesis/population/spatial/primary/candidates.py
@@ -82,7 +82,7 @@ def sample_locations(context, arguments):
     return df_result
 
 def process(context, purpose, random, df_persons, df_od, df_locations,step_name):
-    df_persons = df_persons[df_persons["has_%s_trip" % purpose]]
+    df_persons = df_persons[df_persons["requires_{}_location".format(purpose)]]
 
     # Sample commute flows based on population
     df_demand = df_persons.groupby("commune_id",observed=False).size().reset_index(name = "count")
@@ -116,16 +116,17 @@ def process(context, purpose, random, df_persons, df_od, df_locations,step_name)
 
 def execute(context):
     # Prepare population data
-    df_persons = context.stage("synthesis.population.enriched")[["person_id", "household_id", "age_range"]].copy()
+    df_persons = context.stage("synthesis.population.enriched")[["person_id", "household_id", "age_range", 
+        "employed", "studies"]].copy()
     df_trips = context.stage("synthesis.population.trips")
 
-    df_persons["has_work_trip"] = df_persons["person_id"].isin(df_trips[
+    df_persons["requires_work_location"] = df_persons["person_id"].isin(df_trips[
         (df_trips["following_purpose"] == "work") | (df_trips["preceding_purpose"] == "work")
-    ]["person_id"])
+    ]["person_id"]) | df_persons["employed"]
     
-    df_persons["has_education_trip"] = df_persons["person_id"].isin(df_trips[
+    df_persons["requires_education_location"] = df_persons["person_id"].isin(df_trips[
         (df_trips["following_purpose"] == "education") | (df_trips["preceding_purpose"] == "education")
-    ]["person_id"])
+    ]["person_id"]) | df_persons["studies"]
 
     df_homes = context.stage("synthesis.population.spatial.home.zones")
     df_persons = pd.merge(df_persons, df_homes, on = "household_id")
@@ -158,7 +159,7 @@ def execute(context):
     return dict(
         work_candidates = df_work,
         education_candidates = df_education,
-        persons = df_persons[df_persons["has_work_trip"] | df_persons["has_education_trip"]][[
-            "person_id", "household_id", "age_range", "commune_id", "has_work_trip", "has_education_trip"
+        persons = df_persons[df_persons["requires_work_location"] | df_persons["requires_education_location"]][[
+            "person_id", "household_id", "age_range", "commune_id", "requires_work_location", "requires_education_location"
         ]]
     )

--- a/synthesis/population/spatial/primary/locations.py
+++ b/synthesis/population/spatial/primary/locations.py
@@ -84,8 +84,8 @@ def execute(context):
     df_persons = data["persons"]
 
     # Separate data set
-    df_work = df_persons[df_persons["has_work_trip"]]
-    df_education = df_persons[df_persons["has_education_trip"]]
+    df_work = df_persons[df_persons["requires_work_location"]]
+    df_education = df_persons[df_persons["requires_education_location"]]
 
     # Attach home locations
     df_home = context.stage("synthesis.population.spatial.home.locations")

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -120,7 +120,7 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_activities.csv",
         "{}/ile_de_france_activities.csv".format(output_path),
-        "9f605e5fe099e905fdd0682079b3d8fc")
+        "a009ebdc536562991a6f968ca31296de")
 
     manager.check(
         "ile_de_france_trips.csv",
@@ -140,12 +140,12 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_activities.gpkg",
         "{}/ile_de_france_activities.gpkg".format(output_path),
-        "43719a72b501f80ce42884e8e4cd22d3")
+        "ba4f6d48324dfa3fcc8b2114f21c4692")
 
     manager.check(
         "ile_de_france_commutes.gpkg",
         "{}/ile_de_france_commutes.gpkg".format(output_path),
-        "1955638da2027ee8296f425b8023a476")
+        "8b7297f9ae9fb415ed9e0a54c06ecb08")
 
     manager.check(
         "ile_de_france_homes.gpkg",
@@ -155,7 +155,7 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_trips.gpkg",
         "{}/ile_de_france_trips.gpkg".format(output_path),
-        "661ce98271c8dc17aa3b1a3f0fb10085")
+        "bd5436465aab9d9b2e0c28702c64b05d")
 
     manager.finish()
 


### PR DESCRIPTION
Currently, we only generate *work* and *education* locations for people that actually have *work* or *education* in their activity chain. However, some people may just be sick or stay at home for whatever reason.

This PR extends the scope to all persons that gave *employed = True* or *studies = True*. This doesn't change anything for now, since activity chains without the respective activity will not make use of the generated location. But there is another PR upcoming that extracts the workplace and education place from the synthetic population as an output file. 