### PR TITLE
perf: reduce memory footprint of od cleaning

### DIFF
--- a/data/od/cleaned.py
+++ b/data/od/cleaned.py
@@ -47,27 +47,30 @@ def execute(context):
         raise RuntimeError("Found additional communes: %s" % excess_communes)
 
     # Clean commute mode for work
-    df_work["commute_mode"] = ""
-    df_work.loc[df_work["TRANS"] == 1, "commute_mode"] = "no transport"
-    df_work.loc[df_work["TRANS"] == 2, "commute_mode"] = "walk"
-    df_work.loc[df_work["TRANS"] == 3, "commute_mode"] = "bike"
-    df_work.loc[df_work["TRANS"] == 4, "commute_mode"] = "car"
-    df_work.loc[df_work["TRANS"] == 5, "commute_mode"] = "car"
-    df_work.loc[df_work["TRANS"] == 6, "commute_mode"] = "pt"
-    assert not np.any(df_work["commute_mode"] == "")
-    df_work["commute_mode"] = df_work["commute_mode"].astype("category")
-    
-    
+    categories = ["no transport", "walk", "bike", "car", "pt"]
+
+    df_work["commute_mode"] = pd.Categorical.from_codes(df_work["TRANS"].map({
+        1: categories.index("no transport"),
+        2: categories.index("walk"),
+        3: categories.index("bike"),
+        4: categories.index("car"), 
+        5: categories.index("car"),
+        6: categories.index("pt"),
+    }), categories)
 
     # Clean age range for education
+    categories = ["primary_school", "middle_school", "high_school", "higher_education"]
+
     df_education["AGEREV10"] = df_education["AGEREV10"].astype(int)
-    df_education["age_range"] = ""
-    df_education.loc[df_education["AGEREV10"] <= 6, "age_range"] = "primary_school"
-    df_education.loc[df_education["AGEREV10"] == 11, "age_range"] = "middle_school"
-    df_education.loc[df_education["AGEREV10"] == 15, "age_range"] = "high_school"
-    df_education.loc[df_education["AGEREV10"] >= 18, "age_range"] = "higher_education"
-    assert not np.any(df_education["age_range"] == "")
-    df_education["age_range"] = df_education["age_range"].astype("category")
+    df_education["age_code"] = 0
+
+    df_education.loc[df_education["AGEREV10"] <= 6, "age_code"] = 0
+    df_education.loc[df_education["AGEREV10"] == 11, "age_code"] = 1
+    df_education.loc[df_education["AGEREV10"] == 15, "age_code"] = 2
+    df_education.loc[df_education["AGEREV10"] >= 18, "age_code"] = 3
+
+    df_education["age_range"] = pd.Categorical.from_codes(
+        df_education["age_code"], categories)
 
     # Aggregate the flows
     print("Aggregating work ...")

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -120,7 +120,7 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_activities.csv",
         "{}/ile_de_france_activities.csv".format(output_path),
-        "a009ebdc536562991a6f968ca31296de")
+        "dfa5cb21b7922539e18c99c82be092a0")
 
     manager.check(
         "ile_de_france_trips.csv",
@@ -140,12 +140,12 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_activities.gpkg",
         "{}/ile_de_france_activities.gpkg".format(output_path),
-        "ba4f6d48324dfa3fcc8b2114f21c4692")
+        "7cf88ff15a55c7397650f38866acdccb")
 
     manager.check(
         "ile_de_france_commutes.gpkg",
         "{}/ile_de_france_commutes.gpkg".format(output_path),
-        "8b7297f9ae9fb415ed9e0a54c06ecb08")
+        "ec399d78714a711d7e4b998aa570a6f3")
 
     manager.check(
         "ile_de_france_homes.gpkg",
@@ -155,7 +155,7 @@ def _test_determinism(index, data_path, tmpdir):
     manager.check(
         "ile_de_france_trips.gpkg",
         "{}/ile_de_france_trips.gpkg".format(output_path),
-        "bd5436465aab9d9b2e0c28702c64b05d")
+        "e87f1c8dae2dc376eb74164a90605cc5")
 
     manager.finish()
 


### PR DESCRIPTION
When running the pipeline for entire France, the `data.od.cleaned` step takes a lot of memory due to the duplication of the different modes as strings and subsequent transformation into a `category`. This PR makes the step much more efficient by constructing the categorical column by index.