### PR TITLE
fix: bdtopo in Ardennes

### DIFF
--- a/data/bdtopo/raw.py
+++ b/data/bdtopo/raw.py
@@ -69,13 +69,13 @@ def execute(context):
             final_count = len(df_buildings)
             print("    {}/{} filtered duplicates".format(initial_count - final_count, initial_count))
 
-            # special fix for Ardennes
-            fix_ardennes(df_buildings)
-
             initial_count = len(df_buildings)
             df_buildings = gpd.sjoin(df_buildings, df_departments, predicate = "within")
             final_count = len(df_buildings)
             print("    {}/{} filtered spatially".format(initial_count - final_count, initial_count))
+
+            # special fix for Ardennes
+            fix_ardennes(df_buildings)
 
             initial_count = len(df_buildings)
             df_buildings = df_buildings[df_buildings["housing"] > 0]

--- a/data/bdtopo/raw.py
+++ b/data/bdtopo/raw.py
@@ -65,19 +65,22 @@ def execute(context):
             print("  Filtering ...")
 
             initial_count = len(df_buildings)
-            df_buildings = df_buildings[df_buildings["housing"] > 0]
-            final_count = len(df_buildings)
-            print("    {}/{} filtered by dwellings".format(initial_count - final_count, initial_count))
-
-            initial_count = len(df_buildings)
             df_buildings = df_buildings[~df_buildings["building_id"].isin(known_ids)]
             final_count = len(df_buildings)
             print("    {}/{} filtered duplicates".format(initial_count - final_count, initial_count))
+
+            # special fix for Ardennes
+            fix_ardennes(df_buildings)
 
             initial_count = len(df_buildings)
             df_buildings = gpd.sjoin(df_buildings, df_departments, predicate = "within")
             final_count = len(df_buildings)
             print("    {}/{} filtered spatially".format(initial_count - final_count, initial_count))
+
+            initial_count = len(df_buildings)
+            df_buildings = df_buildings[df_buildings["housing"] > 0]
+            final_count = len(df_buildings)
+            print("    {}/{} filtered by dwellings".format(initial_count - final_count, initial_count))
 
             df_buildings["department_id"] = df_buildings["departement_id"]
             df_buildings = df_buildings.set_geometry("geometry")
@@ -101,6 +104,20 @@ def find_bdtopo(path):
         raise RuntimeError("BD TOPO data is not available in {}".format(path))
     
     return candidates
+
+def fix_ardennes(df_buildings):
+    """
+    Attention: In Ardennes (08) no information on the number of housing units is
+    available. To be sure that we don't throw away all buildings, we set the 
+    number of housing units to one by default. This has, however, implications
+    in later steps: All buildings are considered as residential candidates and
+    all buildings are weighted uniformly.
+    """
+    f = df_buildings["departement_id"] == "08"
+
+    if np.count_nonzero(f) > 0:
+        print("    ATTENTION: fixing missing information for Ardennes (08), assigning one housing unit to each building")
+        df_buildings.loc[f, "housing"] = 1
 
 def validate(context):
     paths = find_bdtopo("{}/{}".format(context.config("data_path"), context.config("bdtopo_path")))


### PR DESCRIPTION
The Ardennes department does not provide any information on the housing units per building in BD-TOPO. This had as a consequence that all buildings were filtered away. We now apply a special fix for Ardennes and keep all buildings by assigning them exactly one housing unit. This is the best we can do for now.