### PR TITLE
fix: selection of two digit and three digit departments in sirene

### DIFF
--- a/data/sirene/raw_geoloc.py
+++ b/data/sirene/raw_geoloc.py
@@ -28,10 +28,10 @@ def execute(context):
     deps2 = {dep for dep in requested_departements if len(dep) == 2}
     deps3 = {dep for dep in requested_departements if len(dep) == 3}
     assert len(deps2) + len(deps3) == len(requested_departements)
-    if deps2:
-        lf = lf.filter(pl.col("plg_code_commune").str.slice(0, 2).is_in(deps2))
-    if deps3:
-        lf = lf.filter(pl.col("plg_code_commune").str.slice(0, 3).is_in(deps3))
+    lf = lf.filter(
+        pl.col("plg_code_commune").str.slice(0, 2).is_in(deps2) |
+        pl.col("plg_code_commune").str.slice(0, 3).is_in(deps3)
+    )
     df_siret_geoloc = lf.select("siret", "x", "y", "epsg").collect()
     return df_siret_geoloc.to_pandas()
 

--- a/data/sirene/raw_siret.py
+++ b/data/sirene/raw_siret.py
@@ -26,10 +26,10 @@ def execute(context):
     deps2 = {dep for dep in requested_departements if len(dep) == 2}
     deps3 = {dep for dep in requested_departements if len(dep) == 3}
     assert len(deps2) + len(deps3) == len(requested_departements)
-    if deps2:
-        lf = lf.filter(pl.col("codeCommuneEtablissement").str.slice(0, 2).is_in(deps2))
-    if deps3:
-        lf = lf.filter(pl.col("codeCommuneEtablissement").str.slice(0, 3).is_in(deps3))
+    lf = lf.filter(
+        pl.col("codeCommuneEtablissement").str.slice(0, 2).is_in(deps2) |
+        pl.col("codeCommuneEtablissement").str.slice(0, 3).is_in(deps3)
+    )
 
     df_siret = lf.select(
         "siren",


### PR DESCRIPTION
There has been an edge case in the selection of departments when loading SIRENE data. It was loading *either* departments with two digits *or* only departments with three digits if any of the latter was requested. This probably never happens when generating a synthetic population for simulation (since DOM/TOM are not connected with continental France), but it may happen when generating the French population in general for downstream analysis.