### PR TITLE
fix: relax excess municipalities check

### DIFF
--- a/data/census/filtered.py
+++ b/data/census/filtered.py
@@ -21,11 +21,11 @@ def execute(context):
     df = df[df["departement_id"].isin(requested_departements)]
 
     excess_communes = set(df["commune_id"].unique()) - set(df_codes["commune_id"].unique())
-    if not excess_communes == {"undefined"}:
+    if len(excess_communes) > 0 and not excess_communes == {"undefined"}:
         raise RuntimeError("Found additional communes: %s" % excess_communes)
 
     excess_iris = set(df["iris_id"].unique()) - set(df_codes["iris_id"].unique())
-    if not excess_iris == {"undefined"}:
+    if len(excess_iris) > 0 and not excess_iris == {"undefined"}:
         raise RuntimeError("Found additional IRIS: %s" % excess_iris)
 
     return df


### PR DESCRIPTION
When choosing to only generate for instance department `75` there are no observations with `undefined` municipality in the census data. This generated an error message (checking that the excess municipalities are only `undefied`) that was not intended.